### PR TITLE
fix for bitwise operator typo main 854

### DIFF
--- a/machine-learning/main.c
+++ b/machine-learning/main.c
@@ -851,7 +851,7 @@ void model_prog_compute_grads(model_program* prog) {
     for (i64 i = (i64)prog->size - 1; i >= 0; i--) {
         model_var* cur = prog->vars[i];
 
-        if ((cur->flags * MV_FLAG_REQUIRES_GRAD) == 0) {
+        if ((cur->flags & MV_FLAG_REQUIRES_GRAD) == 0) {
             continue;
         }
 


### PR DESCRIPTION
Hi, 
This one fixes typo in bitwise operator  in gradient check #3 
 